### PR TITLE
feat: add prettier configuration file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,35 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "embeddedLanguageFormatting": "auto",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "always",
+        "printWidth": 80
+      }
+    },
+    {
+      "files": "*.json",
+      "options": {
+        "tabWidth": 2
+      }
+    },
+    {
+      "files": "*.html",
+      "options": {
+        "printWidth": 120
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Add .prettierrc with team-friendly defaults
- Configure single quotes, 2-space indentation
- Set 100 char line width (80 for markdown)
- Add file-specific overrides for md, json, html
- Ensure consistent code formatting across project